### PR TITLE
Use a better unload detection method

### DIFF
--- a/src/Main.lua
+++ b/src/Main.lua
@@ -1,5 +1,3 @@
-local PluginGuiService = game:GetService("PluginGuiService")
-
 return function(plugin, savedState)
 	local Modules = script.Parent.Parent
 	local Roact = require(Modules.Roact)
@@ -67,14 +65,9 @@ return function(plugin, savedState)
 	end)
 
 	local unloadConnection
-	unloadConnection = PluginGuiService.ChildAdded:Connect(function(child)
-		-- Wait, since it's parented before it's named
-		wait(0)
-		if child.Name == "Tag Editor" then
-			print("New tag editor version coming online; unloading the old version")
-			unloadConnection:Disconnect()
-			plugin:unload()
-		end
+	unloadConnection = gui.AncestryChanged:Connect(function()
+		print("New tag editor version coming online; unloading the old version")
+		unloadConnection:Disconnect()
+		plugin:unload()
 	end)
-
 end


### PR DESCRIPTION
Builds on #41. This uses a more precise and faster unload detection method. Instead of detecting for a new `PluginGui` instance with the correct name, which is prone to name collisions, this detects when the old instance is removed and unloads the plugin along with it.