### PR TITLE
Checks if the tag you're adding has a line break character at the end…

### DIFF
--- a/src/TagManager.lua
+++ b/src/TagManager.lua
@@ -271,6 +271,9 @@ function TagManager:_setProp(tagName, key, value)
 end
 
 function TagManager:AddTag(name)
+	if string.byte(string.sub(name, #name, #name)) == 13 then
+		name = string.sub(name, 1, #name-1)
+	end
 	if self.tags[name] then
 		return
 	end


### PR DESCRIPTION
… of it and deletes it if it does

I was trying to debug my code for about an hour since it wasn't able to detect the new tag that I had added and set to a model using the tag editor. It turns out that an invisible character equal to string.char(13) was added to the end of the name. This made it so that it was technically a different name than the one I was checking for in my script. So there should be some checking for this character at the end of the name of tags when they're being added to avoid this confusion.