### PR TITLE
Add ability to have multiple tag containers with "TagEditorTagContainer" 

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,0 +1,3 @@
+[tools]
+rojo = { source = "rojo-rbx/rojo", version = "7.0.0" }
+selene = { source = "Kampfkarren/selene", version = "0.14.0" }

--- a/src/Maid.lua
+++ b/src/Maid.lua
@@ -21,6 +21,10 @@ function Maid:__newindex(key, newTask)
 	end
 	local tasks = self._tasks
 	local oldTask = tasks[key]
+	if oldTask == newTask then
+		return
+	end
+
 	tasks[key] = newTask
 
 	if oldTask then

--- a/src/TagManager.lua
+++ b/src/TagManager.lua
@@ -185,7 +185,7 @@ function TagManager:_watchFolder(folder: Folder)
 
 	for _, child in pairs(folder:GetChildren()) do
 		if child:IsA("Configuration") then
-			self:_watchChild(child)
+			maid[instance] = self:_watchChild(child)
 		end
 	end
 


### PR DESCRIPTION
This feature adds support for containers labeled with "TagEditorTagContainer" which will allow these tags to be exported by packages for consumption elsewhere. This is good because tags can be coupled to source code and customized more deeply. 

I recommend reviewing commit-by-commit, as each contains a logical change which should be easy to validate. 