### PR TITLE
Changed Icon Size and Position

### DIFF
--- a/src/Components/WorldView/IconAdorn.lua
+++ b/src/Components/WorldView/IconAdorn.lua
@@ -20,10 +20,11 @@ local function IconAdorn(props)
 	end
 	return Roact.createElement("BillboardGui", {
 		Adornee = props.Adornee,
-		Size = UDim2.new(#props.Icon, 0, 1, 0),
-		SizeOffset = Vector2.new(0.5, 0.5),
-		ExtentsOffsetWorldSpace = Vector3.new(1, 1, 1),
-		AlwaysOnTop = props.AlwaysOnTop,
+        Size = UDim2.new(1.5, 0, 1.5, 0),
+        SizeOffset = Vector2.new(0.5, 0.5),
+        ExtentsOffsetWorldSpace = Vector3.new(0,0,0),
+        StudsOffset = Vector3.new(-.75,-.75,0),
+        AlwaysOnTop = props.AlwaysOnTop,
 	}, children)
 end
 

--- a/src/Components/WorldView/IconAdorn.lua
+++ b/src/Components/WorldView/IconAdorn.lua
@@ -20,10 +20,9 @@ local function IconAdorn(props)
 	end
 	return Roact.createElement("BillboardGui", {
 		Adornee = props.Adornee,
-        Size = UDim2.new(1.5, 0, 1.5, 0),
+        Size = UDim2.fromScale(1.5, 1.5),
         SizeOffset = Vector2.new(0.5, 0.5),
-        ExtentsOffsetWorldSpace = Vector3.new(0,0,0),
-        StudsOffset = Vector3.new(-.75,-.75,0),
+        StudsOffset = Vector3.new(-0.75, -0.75, 0.0),
         AlwaysOnTop = props.AlwaysOnTop,
 	}, children)
 end


### PR DESCRIPTION
Currently, Icon visualization is small and not centered, which looks confusing.

This pr changes its position and size to make it more clear and useful
before/after
![image](https://user-images.githubusercontent.com/34089907/184249254-763e96db-cf06-4d3d-a671-d96c10deac7d.png)
![image](https://user-images.githubusercontent.com/34089907/184249265-4f492bff-47a6-4bb0-869d-dc712c7e091b.png)
