### PR TITLE
Made the Tag editor button clickable when viewport hidden and migrated a few deprecated members

### DIFF
--- a/src/Main.lua
+++ b/src/Main.lua
@@ -27,7 +27,7 @@ return function(plugin, savedState)
 	local toolbar = plugin:CreateToolbar(tr("Toolbar_InstanceTagging_Title") .. displaySuffix)
 
 	local function pluginButton(key: string, icon: string): PluginToolbarButton
-		return plugin:button(
+		return toolbar:CreateButton(
 			toolbar,
 			key,
 			tr("PluginButton_" .. key .. "_ToolTip"),

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -37,6 +37,8 @@ return function(plugin, savedState)
 	end
 
 	local toggleButton = pluginButton("TagWindow", "http://www.roblox.com/asset/?id=1367281857")
+  toggleButton.ClickableWhenViewportHidden=true
+	
 	local worldViewButton = pluginButton("WorldView", "http://www.roblox.com/asset/?id=1367285594")
 
 	local store = Rodux.Store.new(Reducer, savedState)
@@ -51,7 +53,7 @@ return function(plugin, savedState)
 	end)
 
 	local info = DockWidgetPluginGuiInfo.new(Enum.InitialDockState.Right, false, false, 0, 0)
-	local gui = plugin:createDockWidgetPluginGui("TagEditor" .. nameSuffix, info)
+	local gui = plugin:CreateDockWidgetPluginGui("TagEditor" .. nameSuffix, info)
 	gui.Name = "TagEditor" .. nameSuffix
 	gui.Title = tr("PluginGui_TagEditor_Title") .. displaySuffix
 	gui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -24,7 +24,7 @@ end
 return function(plugin, savedState)
 	local displaySuffix, nameSuffix = getSuffix(plugin)
 
-	local toolbar = plugin:toolbar(tr("Toolbar_InstanceTagging_Title") .. displaySuffix)
+	local toolbar = plugin:CreateToolbar(tr("Toolbar_InstanceTagging_Title") .. displaySuffix)
 
 	local function pluginButton(key: string, icon: string): PluginToolbarButton
 		return plugin:button(
@@ -37,7 +37,7 @@ return function(plugin, savedState)
 	end
 
 	local toggleButton = pluginButton("TagWindow", "http://www.roblox.com/asset/?id=1367281857")
-  toggleButton.ClickableWhenViewportHidden=true
+    toggleButton.ClickableWhenViewportHidden=true
 	
 	local worldViewButton = pluginButton("WorldView", "http://www.roblox.com/asset/?id=1367285594")
 
@@ -58,6 +58,10 @@ return function(plugin, savedState)
 	gui.Title = tr("PluginGui_TagEditor_Title") .. displaySuffix
 	gui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
 	gui.RootLocalizationTable = script.Parent.Localization
+	gui:BindToClose(function()
+		toggleButton:SetActive(false)
+	end)
+
 	toggleButton:SetActive(gui.Enabled)
 
 	local connection = toggleButton.Click:Connect(function()

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -73,7 +73,7 @@ return function(plugin, savedState)
 	local function createAction(id: string, icon: string?, allowBinding: boolean?): PluginAction
 		local label = tr("PluginAction_" .. id .. "_Label")
 		local description = tr("PluginAction_" .. id .. "_Description")
-		return plugin:createAction(prefix .. id, label, description, icon, allowBinding)
+		return plugin:CreatePluginAction(prefix .. id, label, description, icon, allowBinding)
 	end
 
 	local changeIconAction = createAction("ChangeIcon")
@@ -99,7 +99,7 @@ return function(plugin, savedState)
 	local visualizeIcon = createAction("Visualize_Icon")
 	local visualizeHighlight = createAction("Visualize_Highlight")
 
-	local visualizeMenu: PluginMenu = plugin:createMenu("TagMenu_VisualizeAs", tr("PluginMenu_TagMenu_VisualizeAs"))
+	local visualizeMenu: PluginMenu = plugin:CreatePluginMenu("TagMenu_VisualizeAs", tr("PluginMenu_TagMenu_VisualizeAs"))
 	visualizeMenu:AddAction(visualizeBox)
 	visualizeMenu:AddAction(visualizeSphere)
 	visualizeMenu:AddAction(visualizeOutline)
@@ -107,7 +107,7 @@ return function(plugin, savedState)
 	visualizeMenu:AddAction(visualizeIcon)
 	visualizeMenu:AddAction(visualizeHighlight)
 
-	local tagMenu: PluginMenu = plugin:createMenu("TagMenu")
+	local tagMenu: PluginMenu = plugin:CreatePluginMenu("TagMenu")
 	tagMenu:AddAction(viewTaggedAction)
 	tagMenu:AddAction(selectAllAction)
 	tagMenu:AddMenu(visualizeMenu)
@@ -143,7 +143,7 @@ return function(plugin, savedState)
 
 	local instance = Roact.mount(element, gui, "TagEditor")
 
-	plugin:beforeUnload(function()
+	plugin.Unloading:Connect(function()
 		Roact.unmount(instance)
 		connection:Disconnect()
 		worldViewConnection:Disconnect()


### PR DESCRIPTION
Since the Tag Editor is not relevant to the viewport, I made it clickable when the viewport is hidden. I migrated things like ```plugin:toolbar```, ```plugin:button```, ```plugin:action``` and ```plugin:unloading``` to ```plugin:CreateToolbar```, ```toolbar:CreateButton```, ```plugin:CreatePluginAction```, ```plugin.Unloading:Connect()``` etc.